### PR TITLE
Support intellij 2024.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.17.2'
+    id 'org.jetbrains.intellij' version '1.17.3'
 }
 
 group 'com.samjakob'
-version '2023.3'
+version '2024.1'
 
 sourceCompatibility = 17
 targetCompatibility = 17
@@ -17,7 +17,7 @@ sourceSets.main.java.srcDirs 'src/main/gen'
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2023.3'
+    version = '2024.1'
     buildSearchableOptions.enabled = false
 }
 


### PR DESCRIPTION
Followed the last PR as an example to support the latest intellij. I tested this by running the buildPlugin task. There's a zip file under build/distributions I installed into Intellij.