### PR TITLE
Update plugin so it works in 242.x builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ Temporary Items
 
 # Env
 .env
+
+.intellijPlatform
+*.iml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/intellij-askama-template-plugin.iml
+++ b/.idea/intellij-askama-template-plugin.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,20 @@
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="IntelliJ Repository (Snapshots)" />
+      <option name="name" value="IntelliJ Repository (Snapshots)" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/snapshots" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="IntelliJ Platform Dependencies Repository" />
+      <option name="name" value="IntelliJ Platform Dependencies Repository" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/intellij-dependencies" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="JetBrains Marketplace Repository" />
+      <option name="name" value="JetBrains Marketplace Repository" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/plugins.jetbrains.com/maven" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,35 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.17.3'
+    id 'org.jetbrains.intellij.platform' version '2.0.1'
 }
 
 group 'com.samjakob'
-version '2024.1'
-
-sourceCompatibility = 17
-targetCompatibility = 17
+version '2024.2'
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        bundledPlugin 'com.intellij.java'
+        intellijIdeaCommunity '2024.2'
+
+        instrumentationTools()
+    }
 }
 
 sourceSets.main.java.srcDirs 'src/main/gen'
 
-// See https://github.com/JetBrains/gradle-intellij-plugin/
-intellij {
-    version = '2024.1'
-    buildSearchableOptions.enabled = false
-}
-
-patchPluginXml {
+intellijPlatform {
+    buildSearchableOptions = false
+    pluginConfiguration {
+        name = 'askama-template-support'
+    }
+    patchPluginXml {}
 }
 
 def env = new Properties()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Sep 22 01:22:43 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hello,

I am a heavy user of EAPs on various IDEs so I have seen the message about this plugin not having support for such version many times. Today I decided to fix it. I'm presenting a PR which should be the bare minimum needed to get it compiling for newer IDEs.

The most notable change is going from the 1.x version of the IntelliJ Platform to the 2.x one, which has breaking changes.

I don't know very much about Java and its tooling, but I managed to compile in IDEA it and it works loaded in RustRover.

There are other breaking changes, like having to bump versions for Gradle and JDK, but those are required by the aforementioned Platform.

Finally, this includes two commits, but it can be squashed no problem. The first one was for usability.

Let me know if you need anything more.