### PR TITLE
Add jump-to-struct support for multi-file projects

### DIFF
--- a/src/main/java/com/samjakob/askama/actions/AskamaJumpToRustStruct.java
+++ b/src/main/java/com/samjakob/askama/actions/AskamaJumpToRustStruct.java
@@ -127,7 +127,8 @@ public class AskamaJumpToRustStruct extends AskamaActionBase implements FileBase
                             }
                         }
                     });
-                    return false;
+                    // Continue iteration
+                    return true;
                 }
 
                 return true;


### PR DESCRIPTION
The jump-to-struct action wasn't working on a project with multiple rust files -- from debugging, it seemed to stop looking after the first (non-askama) rust file it found.

Changing the return to true fixed it, as it continues the iteration onto more files.